### PR TITLE
Switch to mainspring to drive clockwork.

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -2,7 +2,7 @@ name: Update SpacetimeDB Bindings
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 * * * *'
+    - cron: '37 5 * * *'
 
 jobs:
   generate-bindings:

--- a/.github/workflows/bsatn.yml
+++ b/.github/workflows/bsatn.yml
@@ -2,7 +2,7 @@ name: Update BSATN game data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '42 * * * *'
+    - cron: '42 5 * * *'
 
 jobs:
   bsatn:

--- a/.github/workflows/cereal-cs.yml
+++ b/.github/workflows/cereal-cs.yml
@@ -2,7 +2,7 @@ name: Update C# SDK serialized game data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '42 * * * *'
+    - cron: '42 5 * * *'
 
 jobs:
   cereal-cs:

--- a/.github/workflows/nodeindex.yml
+++ b/.github/workflows/nodeindex.yml
@@ -2,7 +2,7 @@ name: Update nodeindex
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 * * * *'
+    - cron: '37 5 * * *'
 
 jobs:
   build-cacheless-bindings:

--- a/.github/workflows/sats-json.yml
+++ b/.github/workflows/sats-json.yml
@@ -2,7 +2,7 @@ name: Update SATS-JSON game data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 * * * *'
+    - cron: '37 5 * * *'
 
 jobs:
   sats-json:

--- a/scripts/assets/font_icons.json
+++ b/scripts/assets/font_icons.json
@@ -1,6 +1,6 @@
 {
   "buff_desc": "icon_asset_name",
-  "combat_action_desc_v3": "icon_asset_name",
+  "combat_action_desc": "icon_asset_name",
   "empire_icon_desc": "icon_unicode",
   "npc_desc": "icon_address",
   "prospecting_desc": "icon_asset_path",

--- a/utils/mainspring/.gitignore
+++ b/utils/mainspring/.gitignore
@@ -1,0 +1,29 @@
+# Configuration
+config.yml
+.env
+.env.local
+
+# Logs
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/utils/mainspring/Dockerfile
+++ b/utils/mainspring/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY run.py ./
+COPY mainspring/ ./mainspring/
+
+VOLUME ["/app/config"]
+
+ENV PYTHONUNBUFFERED=1
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD python -c "import os; exit(0 if os.path.exists('mainspring.log') else 1)"
+
+CMD ["python", "run.py", "-c", "/app/config/config.yml"]

--- a/utils/mainspring/config.example.yml
+++ b/utils/mainspring/config.example.yml
@@ -1,0 +1,95 @@
+# Mainspring Configuration
+# Copy this file to config.yml and update with your values
+
+# SpacetimeDB Connection
+spacetimedb:
+  host: "bitcraft-early-access.spacetimedb.com"
+  global_module: "bitcraft-global"
+  region_module: "bitcraft-2"
+  bearer_token: ""
+
+# GitHub Actions (global defaults)
+github:
+  owner: "BitCraftToolBox"
+  repo: "automata"
+  token: ""  # Personal access token with workflow permissions
+
+# Discord Webhooks (global defaults)
+discord:
+  enabled: false
+  webhook_url: ""
+
+# Tasks Configuration
+tasks:
+  # Schema Monitor - checks for schema changes
+  schema_monitor:
+    # type: schema_monitor  # Optional: can be omitted if key matches type
+    enabled: true
+    interval: 300  # Check every 5 minutes
+    actions:
+      - type: discord
+        message: "Schema changed! Triggering bindings workflow..."
+        # Optional per-action overrides:
+        # enabled: true
+        # webhook_url: "https://discord.com/api/webhooks/..."
+      - type: github_dispatch
+        workflow: "bindings.yml"
+        # Optional per-action overrides:
+        # owner: "DifferentOrg"
+        # repo: "different-repo"
+        # token: "different_token"
+      - type: restart_task
+        task: "table_subscriber"
+        # Optional: conditional execution based on context
+        # if: "'static_tables' in changes"  # Only restart if static tables changed
+  
+  # Table Subscriber - monitors SpacetimeDB tables
+  table_subscriber:
+    enabled: true
+    reconnect_on_error: true
+    trigger_interval: 60  # Seconds between action triggers (to avoid spam)
+    
+    # Option 1: Custom SQL queries (highest priority)
+    # queries:
+    #   - "SELECT * FROM building_desc WHERE rarity > 2;"
+    #   - "SELECT * FROM item_desc;"
+    
+    # Option 2: Specific table names (converted to SELECT * FROM {table})
+    # tables: ["building_desc", "item_desc", "crafting_desc"]
+    
+    # Option 3: Empty = auto-detect static tables (desc tables + extras)
+    tables: []
+    queries: []
+    
+    actions:
+      - type: discord
+        message: "Game data updated: {description}"
+        # Example: Use different webhook for data updates
+        # webhook_url: "https://discord.com/api/webhooks/.../data-channel"
+      - type: github_dispatch
+        workflow: "sats-json.yml"
+  
+  # Asset Monitor - checks Steam depot manifest
+  asset_monitor:
+    enabled: true
+    interval: 3600  # Check every hour
+    app_id: 3454650  # BitCraft Steam app ID
+    depot_id: 3454651  # Depot ID for Windows build
+    branches: ["public", "preview"]
+    # Optional: Steam credentials (can use anonymous login without these)
+    steam_username: ""
+    steam_password: ""
+    actions:
+      - type: discord
+        message: "New game assets detected on {branches_changed}!"
+        # Example: Send to different channel
+        # webhook_url: "https://discord.com/api/webhooks/.../assets-channel"
+      - type: github_dispatch
+        workflow: "assets.yml"
+        # Example: only trigger for preview branch
+        # if: "'preview' in branches_changed"
+
+# Logging
+logging:
+  level: "INFO"  # DEBUG, INFO, WARNING, ERROR
+  file: "mainspring.log"

--- a/utils/mainspring/mainspring/__init__.py
+++ b/utils/mainspring/mainspring/__init__.py
@@ -1,0 +1,40 @@
+"""
+Mainspring - Event-driven task orchestrator for BitCraft data extraction
+
+Main exports:
+- Mainspring: Main application class
+- EventBus: Event communication system
+- Task, Action: Base classes for extensibility
+"""
+
+from .mainspring import Mainspring, main
+from .core import EventBus, Task, Action, Event, EventType, ChangeDetector, PeriodicChangeMonitorTask
+from .tasks import (
+    SchemaMonitorTask,
+    TableSubscriberTask, 
+    AssetMonitorTask,
+    WorkflowMonitorTask
+)
+from .actions import GitHubDispatchAction, DiscordWebhookAction, RestartTaskAction, LogAction
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Mainspring",
+    "main",
+    "EventBus",
+    "Task",
+    "Action",
+    "Event",
+    "EventType",
+    "ChangeDetector",
+    "PeriodicChangeMonitorTask",
+    "SchemaMonitorTask",
+    "TableSubscriberTask",
+    "AssetMonitorTask",
+    "WorkflowMonitorTask",
+    "GitHubDispatchAction",
+    "DiscordWebhookAction",
+    "RestartTaskAction",
+    "LogAction",
+]

--- a/utils/mainspring/mainspring/actions/__init__.py
+++ b/utils/mainspring/mainspring/actions/__init__.py
@@ -1,0 +1,17 @@
+"""
+Action implementations for mainspring.
+
+These actions can be triggered when tasks detect changes.
+"""
+
+from .github_dispatch import GitHubDispatchAction
+from .discord_webhook import DiscordWebhookAction
+from .restart_task import RestartTaskAction
+from .log import LogAction
+
+__all__ = [
+    "GitHubDispatchAction",
+    "DiscordWebhookAction",
+    "RestartTaskAction",
+    "LogAction",
+]

--- a/utils/mainspring/mainspring/actions/discord_webhook.py
+++ b/utils/mainspring/mainspring/actions/discord_webhook.py
@@ -1,0 +1,67 @@
+"""
+Discord webhook action.
+"""
+
+from typing import Any, Dict, Optional
+import aiohttp
+
+from ..core import Action, EventBus
+
+
+class DiscordWebhookAction(Action):
+    """
+    Posts a message to a Discord webhook.
+    Supports per-action config overrides for webhook_url and enabled status.
+    """
+    
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus,
+                 discord_config: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.discord_config = discord_config
+        self.message_template = config.get("message", "Change detected!")
+        
+        # Allow per-action overrides of Discord config
+        self.enabled = config.get("enabled", discord_config.get("enabled", False))
+        self.webhook_url = config.get("webhook_url", discord_config.get("webhook_url"))
+    
+    async def execute(self, context: Dict[str, Any]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """Post to Discord webhook"""
+        if not self.enabled:
+            self._logger.debug("Discord webhooks disabled, skipping")
+            return True, None
+
+        webhook_url = self.webhook_url
+        if not webhook_url:
+            self._logger.warning("Discord webhook URL not configured")
+            return False, None
+        
+        # Format message with context
+        try:
+            message = self.message_template.format(**context)
+        except KeyError:
+            message = self.message_template
+        
+        payload = {
+            "embeds": [{
+                "title": "Mainspring Update",
+                "description": message,
+                "color": 0x00ff00,
+                "fields": [
+                    {"name": "Source", "value": context.get("source", "Unknown"), "inline": True},
+                ]
+            }]
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(webhook_url, json=payload) as response:
+                    if response.status in (200, 204):
+                        self._logger.info("Discord notification sent")
+                        return True, None
+                    else:
+                        error_text = await response.text()
+                        self._logger.error(f"Discord webhook failed: {response.status} - {error_text}")
+                        return False, None
+        except Exception as e:
+            self._logger.error(f"Error posting to Discord: {e}", exc_info=True)
+            return False, None

--- a/utils/mainspring/mainspring/actions/github_dispatch.py
+++ b/utils/mainspring/mainspring/actions/github_dispatch.py
@@ -1,0 +1,80 @@
+"""
+GitHub workflow dispatch action.
+"""
+
+from typing import Any, Dict, Optional
+import aiohttp
+
+from ..core import Action, EventBus
+
+
+class GitHubDispatchAction(Action):
+    """
+    Triggers a GitHub Actions workflow via repository_dispatch or workflow_dispatch.
+    Supports per-action config overrides for owner, repo, and token.
+    """
+    
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus,
+                 github_config: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.github_config = github_config
+        self.workflow = config.get("workflow")
+        self.inputs = config.get("inputs", {})
+        
+        # Allow per-action overrides of GitHub config
+        self.owner = config.get("owner", github_config.get("owner"))
+        self.repo = config.get("repo", github_config.get("repo"))
+        self.token = config.get("token", github_config.get("token"))
+        
+        if not all([self.workflow, self.owner, self.repo, self.token]):
+            raise ValueError(f"GitHubDispatchAction {name} has incomplete configuration")
+    
+    async def execute(self, context: Dict[str, Any]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """Execute the GitHub workflow dispatch"""
+        owner = self.owner
+        repo = self.repo
+        token = self.token
+
+        # Merge context into inputs
+        inputs = {**self.inputs, **context.get("inputs", {})}
+        
+        url = f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{self.workflow}/dispatches"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2026-03-10"
+        }
+        params = {
+            "return_run_details": "true"
+        }
+        data = {
+            "ref": "main",
+            "inputs": inputs
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=data, headers=headers, params=params) as response:
+                    if response.status in (200, 204):
+                        self._logger.info(f"Successfully triggered workflow: {self.workflow}")
+                        
+                        action_data = {
+                            "workflow": self.workflow,
+                            "owner": owner,
+                            "repo": repo,
+                        }
+                        
+                        # If GitHub returns run details, extract the API URL
+                        if response.status == 200:
+                            result = await response.json()
+                            if "run_url" in result:
+                                action_data["run_url"] = result["run_url"]
+                        
+                        return True, action_data
+                    else:
+                        error_text = await response.text()
+                        self._logger.error(f"Failed to trigger workflow: {response.status} - {error_text}")
+                        return False, None
+        except Exception as e:
+            self._logger.error(f"Error triggering GitHub workflow: {e}", exc_info=True)
+            return False, None

--- a/utils/mainspring/mainspring/actions/log.py
+++ b/utils/mainspring/mainspring/actions/log.py
@@ -1,0 +1,29 @@
+"""
+Simple logging action for testing and debugging.
+"""
+
+from typing import Any, Dict, Optional
+
+from ..core import Action, EventBus
+
+
+class LogAction(Action):
+    """
+    Simple logging action for testing and debugging.
+    """
+    
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus):
+        super().__init__(name, config, event_bus)
+        self.log_level = config.get("level", "INFO")
+        self.message_template = config.get("message", "Change detected: {source}")
+    
+    async def execute(self, context: Dict[str, Any]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """Log the change"""
+        try:
+            message = self.message_template.format(**context)
+        except KeyError:
+            message = f"{self.message_template} - Context: {context}"
+        
+        log_method = getattr(self._logger, self.log_level.lower(), self._logger.info)
+        log_method(message)
+        return True, None

--- a/utils/mainspring/mainspring/actions/restart_task.py
+++ b/utils/mainspring/mainspring/actions/restart_task.py
@@ -1,0 +1,39 @@
+"""
+Restart task action.
+"""
+
+from typing import Any, Dict, Optional
+
+from ..core import Action, EventBus
+
+
+class RestartTaskAction(Action):
+    """
+    Restarts another task in the system.
+    Useful when schema changes require re-subscribing to tables.
+    """
+    
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus,
+                 task_registry: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.task_registry = task_registry
+        self.target_task = config.get("task")
+        
+        if not self.target_task:
+            raise ValueError("RestartTaskAction requires 'task' in config")
+    
+    async def execute(self, context: Dict[str, Any]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """Restart the target task"""
+        task = self.task_registry.get(self.target_task)
+        
+        if not task:
+            self._logger.error(f"Task '{self.target_task}' not found in registry")
+            return False, None
+        
+        try:
+            self._logger.info(f"Restarting task: {self.target_task}")
+            await task.restart()
+            return True, None
+        except Exception as e:
+            self._logger.error(f"Error restarting task: {e}", exc_info=True)
+            return False, None

--- a/utils/mainspring/mainspring/core.py
+++ b/utils/mainspring/mainspring/core.py
@@ -1,0 +1,324 @@
+"""
+Mainspring - Event-driven task orchestrator for BitCraft data extraction
+
+This module provides the core abstractions for the mainspring system:
+- Task: Abstract base for long-running tasks
+- Action: Abstract base for triggered actions
+- EventBus: Communication between tasks
+- ChangeDetector: Base for detecting changes
+"""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Coroutine
+from collections import defaultdict
+
+
+class EventType(Enum):
+    """Types of events that can occur in the system"""
+    CHANGE_DETECTED = "change_detected"
+    TASK_STARTED = "task_started"
+    TASK_STOPPED = "task_stopped"
+    TASK_ERROR = "task_error"
+    ACTION_TRIGGERED = "action_triggered"
+    ACTION_COMPLETED = "action_completed"
+    ACTION_FAILED = "action_failed"
+
+
+@dataclass
+class Event:
+    """Represents an event in the system"""
+    type: EventType
+    source: str  # Task or action name that generated the event
+    data: Dict[str, Any]
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = datetime.now()
+
+
+class EventBus:
+    """
+    Central event bus for task communication.
+    Allows tasks to publish events and subscribe to events from other tasks.
+    """
+
+    def __init__(self):
+        self._subscribers: Dict[EventType, List[Callable]] = defaultdict(list)
+        self._logger = logging.getLogger("mainspring.eventbus")
+
+    def subscribe(self, event_type: EventType, callback: Callable[[Event], None]):
+        """Subscribe to an event type"""
+        self._subscribers[event_type].append(callback)
+        self._logger.debug(f"Subscribed to {event_type.value}")
+
+    def unsubscribe(self, event_type: EventType, callback: Callable[[Event], None]):
+        """Unsubscribe from an event type"""
+        if callback in self._subscribers[event_type]:
+            self._subscribers[event_type].remove(callback)
+            self._logger.debug(f"Unsubscribed from {event_type.value}")
+
+    async def publish(self, event: Event):
+        """Publish an event to all subscribers"""
+        self._logger.debug(f"Event: {event.type.value} from {event.source}")
+
+        # Call all subscribers for this event type
+        for callback in self._subscribers[event.type]:
+            try:
+                # Support both sync and async callbacks
+                if asyncio.iscoroutinefunction(callback):
+                    await callback(event)
+                else:
+                    callback(event)
+            except Exception as e:
+                self._logger.error(f"Error in event handler: {e}", exc_info=True)
+
+
+class Action(ABC):
+    """
+    Abstract base class for actions that tasks can trigger.
+    Actions are triggered when changes are detected.
+    """
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus):
+        self.name = name
+        self.config = config
+        self.event_bus = event_bus
+        self._logger = logging.getLogger(f"mainspring.actions.{name}")
+
+    @abstractmethod
+    async def execute(self, context: Dict[str, Any]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """
+        Execute the action with the given context.
+        Returns (success: bool, data: Optional[Dict[str, Any]]).
+        Data will be attached to the action_completed event.
+        """
+        pass
+
+    async def trigger(self, context: Dict[str, Any]):
+        """Trigger the action and publish events"""
+        # Check if action has a conditional expression
+        if_condition = self.config.get("if")
+        
+        if if_condition is not None:
+            try:
+                # Evaluate the condition with context in scope
+                # Make context available as both a variable and for key access
+                eval_globals = {"context": context}
+                eval_locals = dict(context)  # Allow direct access to context keys
+                
+                result = eval(if_condition, eval_globals, eval_locals)
+                
+                if not result:
+                    self._logger.debug(f"Skipping action '{self.name}': condition '{if_condition}' evaluated to {result}")
+                    return True  # Return success but skip execution
+            except Exception as e:
+                self._logger.error(f"Error evaluating condition '{if_condition}': {e}", exc_info=True)
+                # On evaluation error, skip the action to be safe
+                return False
+        
+        self._logger.info(f"Triggering action: {self.name}")
+
+        await self.event_bus.publish(Event(
+            type=EventType.ACTION_TRIGGERED,
+            source=self.name,
+            data={"context": context}
+        ))
+
+        try:
+            success, action_data = await self.execute(context)
+
+            if success:
+                # Attach action data (e.g., run_url) to the completed event
+                event_data = {"context": context}
+                if action_data:
+                    event_data["action_data"] = action_data
+                
+                await self.event_bus.publish(Event(
+                    type=EventType.ACTION_COMPLETED,
+                    source=self.name,
+                    data=event_data
+                ))
+            else:
+                await self.event_bus.publish(Event(
+                    type=EventType.ACTION_FAILED,
+                    source=self.name,
+                    data={"context": context, "reason": "Action returned False"}
+                ))
+
+            return success
+        except Exception as e:
+            self._logger.error(f"Action failed: {e}", exc_info=True)
+            await self.event_bus.publish(Event(
+                type=EventType.ACTION_FAILED,
+                source=self.name,
+                data={"context": context, "error": str(e)}
+            ))
+            return False
+
+
+class Task(ABC):
+    """
+    Abstract base class for long-running tasks.
+    Tasks can detect changes and trigger actions.
+    """
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus):
+        self.name = name
+        self.config = config
+        self.event_bus = event_bus
+        self._logger = logging.getLogger(f"mainspring.tasks.{name}")
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self.actions: List[Action] = []
+
+    def add_action(self, action: Action):
+        """Add an action to be triggered when changes are detected"""
+        self.actions.append(action)
+
+    @abstractmethod
+    async def run(self):
+        """
+        Main task loop. Should run until stopped.
+        Must periodically check self._running and exit gracefully when False.
+        """
+        pass
+
+    async def start(self):
+        """Start the task"""
+        if self._running:
+            self._logger.warning(f"Task {self.name} is already running")
+            return
+
+        self._running = True
+        self._logger.info(f"Starting task: {self.name}")
+
+        await self.event_bus.publish(Event(
+            type=EventType.TASK_STARTED,
+            source=self.name,
+            data={}
+        ))
+
+        self._task = asyncio.create_task(self._run_wrapper())
+
+    async def stop(self):
+        """Stop the task gracefully"""
+        if not self._running:
+            return
+
+        self._logger.info(f"Stopping task: {self.name}")
+        self._running = False
+
+        if self._task:
+            try:
+                await asyncio.wait_for(self._task, timeout=10.0)
+            except asyncio.TimeoutError:
+                self._logger.warning(f"Task {self.name} did not stop gracefully, cancelling")
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+
+        await self.event_bus.publish(Event(
+            type=EventType.TASK_STOPPED,
+            source=self.name,
+            data={}
+        ))
+
+    async def restart(self):
+        """Restart the task"""
+        self._logger.info(f"Restarting task: {self.name}")
+        await self.stop()
+        await asyncio.sleep(1)  # Brief pause before restarting
+        await self.start()
+
+    async def _run_wrapper(self):
+        """Wrapper around run() to handle errors"""
+        try:
+            await self.run()
+        except asyncio.CancelledError:
+            self._logger.info(f"Task {self.name} was cancelled")
+            raise
+        except Exception as e:
+            self._logger.error(f"Task {self.name} failed: {e}", exc_info=True)
+            await self.event_bus.publish(Event(
+                type=EventType.TASK_ERROR,
+                source=self.name,
+                data={"error": str(e)}
+            ))
+            self._running = False
+
+    async def trigger_actions(self, context: Dict[str, Any]):
+        """Trigger all configured actions"""
+        self._logger.info(f"Change detected in {self.name}, triggering {len(self.actions)} action(s)")
+
+        await self.event_bus.publish(Event(
+            type=EventType.CHANGE_DETECTED,
+            source=self.name,
+            data=context
+        ))
+
+        # Trigger all actions
+        for action in self.actions:
+            await action.trigger(context)
+
+
+class ChangeDetector(ABC):
+    """
+    Abstract base for detecting changes.
+    Used by tasks to determine if something has changed.
+    """
+
+    @abstractmethod
+    async def has_changed(self) -> Coroutine[Any, Any, tuple[bool, dict[str, Any]]]:
+        """
+        Check if a change has occurred.
+        Returns (changed, context) where context contains information about the change.
+        """
+        pass
+
+
+class PeriodicChangeMonitorTask(Task):
+    """
+    Base class for tasks that periodically check a ChangeDetector.
+    Implements the common pattern of polling a detector at intervals.
+    """
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus):
+        super().__init__(name, config, event_bus)
+        self.interval = config.get("interval", 300)  # Default 5 minutes
+        self.detector: Optional[ChangeDetector] = None  # Subclasses must set this
+
+    async def run(self):
+        """Main monitoring loop - periodically checks detector and triggers actions"""
+        if self.detector is None:
+            self._logger.error("Detector not initialized!")
+            return
+
+        self._logger.info(f"{self.name} started, checking every {self.interval}s")
+
+        while self._running:
+            try:
+                changed, context = await self.detector.has_changed()
+
+                if changed:
+                    self._logger.info("Change detected!")
+                    await self.trigger_actions(context)
+                else:
+                    self._logger.debug("No changes detected")
+
+                # Wait for the interval, but check _running periodically
+                for _ in range(self.interval):
+                    if not self._running:
+                        break
+                    await asyncio.sleep(1)
+
+            except Exception as e:
+                self._logger.error(f"Error in monitor: {e}", exc_info=True)
+                await asyncio.sleep(60)  # Wait a minute before retrying

--- a/utils/mainspring/mainspring/mainspring.py
+++ b/utils/mainspring/mainspring/mainspring.py
@@ -1,0 +1,283 @@
+"""
+Mainspring - Main application
+
+Event-driven task orchestrator for BitCraft data extraction.
+Continuously monitors for changes and triggers GitHub Actions workflows.
+"""
+
+import asyncio
+import logging
+import signal
+import sys
+from pathlib import Path
+from typing import Dict, Any
+import yaml
+import aiohttp
+
+from .core import EventBus, Task, Action, Event, EventType
+from .tasks import SchemaMonitorTask, TableSubscriberTask, AssetMonitorTask, WorkflowMonitorTask
+from .actions import GitHubDispatchAction, DiscordWebhookAction, RestartTaskAction, LogAction
+
+
+def _load_config(config_path: str) -> Dict[str, Any]:
+    """Load configuration from YAML file"""
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+class Mainspring:
+    """
+    Main application that orchestrates tasks and actions.
+    """
+
+    def __init__(self, config_path: str = "config.yml"):
+        self.config = _load_config(config_path)
+        self._setup_logging()
+
+        self.event_bus = EventBus()
+        self.tasks: Dict[str, Task] = {}
+        self.actions: Dict[str, Action] = {}
+        self._shutdown_event = asyncio.Event()
+
+        self._logger = logging.getLogger("mainspring")
+
+        # Setup signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, _):
+        """Handle shutdown signals"""
+        self._logger.info(f"Received signal {signum}, initiating shutdown...")
+        self._shutdown_event.set()
+
+    def _setup_logging(self):
+        """Setup logging configuration"""
+        log_config = self.config.get("logging", {})
+        log_level = log_config.get("level", "INFO")
+        root_log_level = log_config.get("root_level", "INFO")
+        log_file = log_config.get("file")
+
+        # Configure root logger
+        handlers = [logging.StreamHandler(sys.stdout)]
+
+        if log_file:
+            handlers.append(logging.FileHandler(log_file))
+
+        logging.basicConfig(
+            level=getattr(logging, root_log_level.upper()),
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            handlers=handlers
+        )
+        logging.getLogger("mainspring").setLevel(getattr(logging, log_level.upper()))
+
+    def _create_action(self, action_config: Dict[str, Any], task_name: str) -> Action:
+        """Create an action from configuration"""
+        action_type = action_config.get("type")
+        action_name = action_config.get("name", None)
+        action_name = f"{task_name}_{action_type}_{action_name or len(self.actions)}"
+
+        if action_type == "github_dispatch":
+            return GitHubDispatchAction(
+                name=action_name,
+                config=action_config,
+                event_bus=self.event_bus,
+                github_config=self.config.get("github", {})
+            )
+        elif action_type == "discord":
+            return DiscordWebhookAction(
+                name=action_name,
+                config=action_config,
+                event_bus=self.event_bus,
+                discord_config=self.config.get("discord", {})
+            )
+        elif action_type == "restart_task":
+            return RestartTaskAction(
+                name=action_name,
+                config=action_config,
+                event_bus=self.event_bus,
+                task_registry=self.tasks
+            )
+        elif action_type == "log":
+            return LogAction(
+                name=action_name,
+                config=action_config,
+                event_bus=self.event_bus
+            )
+        else:
+            raise ValueError(f"Unknown action type: {action_type}")
+
+    def _create_task(self, task_name: str, task_config: Dict[str, Any]) -> Task:
+        """Create a task from configuration"""
+        stdb_config = self.config.get("spacetimedb", {})
+        github_config = self.config.get("github", {})
+        discord_config = self.config.get("discord", {})
+
+        task_type = task_config.get("type", task_name)
+
+        if task_type == "schema_monitor":
+            task = SchemaMonitorTask(
+                name=task_name,
+                config=task_config,
+                event_bus=self.event_bus,
+                stdb_config=stdb_config
+            )
+        elif task_type == "table_subscriber":
+            task = TableSubscriberTask(
+                name=task_name,
+                config=task_config,
+                event_bus=self.event_bus,
+                stdb_config=stdb_config
+            )
+        elif task_type == "asset_monitor":
+            task = AssetMonitorTask(
+                name=task_name,
+                config=task_config,
+                event_bus=self.event_bus
+            )
+        elif task_type == "workflow_monitor":
+            task = WorkflowMonitorTask(
+                name=task_name,
+                config=task_config,
+                event_bus=self.event_bus,
+                github_config=github_config,
+                discord_config=discord_config
+            )
+        else:
+            raise ValueError(f"Unknown task type: {task_type}")
+
+        # Add actions to the task
+        for action_config in task_config.get("actions", []):
+            action = self._create_action(action_config, task_name)
+            task.add_action(action)
+            self.actions[action.name] = action
+
+        return task
+
+    def _setup_tasks(self):
+        """Setup all tasks from configuration"""
+        task_configs = self.config.get("tasks", {})
+
+        for task_name, task_config in task_configs.items():
+            if not task_config.get("enabled", True):
+                self._logger.info(f"Task {task_name} is disabled, skipping")
+                continue
+
+            try:
+                task = self._create_task(task_name, task_config)
+                self.tasks[task_name] = task
+                self._logger.info(f"Created task: {task_name}")
+            except Exception as e:
+                self._logger.error(f"Failed to create task {task_name}: {e}", exc_info=True)
+
+    def _setup_event_logging(self):
+        """Setup event bus logging for debugging"""
+
+        def log_event(event: Event):
+            if event.type in (EventType.CHANGE_DETECTED, EventType.ACTION_TRIGGERED):
+                self._logger.info(f"[EVENT] {event.type.value}: {event.source}")
+
+        # Subscribe to all event types for logging
+        for event_type in EventType:
+            self.event_bus.subscribe(event_type, log_event)
+
+    async def _send_discord_notification(self, message: str) -> bool:
+        """Send a notification to the global Discord webhook if configured"""
+        discord_config = self.config.get("discord", {})
+        
+        if not discord_config.get("enabled", False):
+            return False
+        
+        webhook_url = discord_config.get("webhook_url")
+        if not webhook_url:
+            return False
+        
+        try:
+            payload = {"content": message}
+            async with aiohttp.ClientSession() as session:
+                async with session.post(webhook_url, json=payload) as response:
+                    if response.status in (200, 204):
+                        self._logger.debug(f"Discord notification sent: {message}")
+                        return True
+                    else:
+                        self._logger.warning(f"Discord notification failed: {response.status}")
+                        return False
+        except Exception as e:
+            self._logger.error(f"Error sending Discord notification: {e}")
+            return False
+
+    async def start(self):
+        """Start all tasks"""
+        self._logger.info("=" * 60)
+        self._logger.info("Starting Mainspring")
+        self._logger.info("=" * 60)
+
+        self._setup_tasks()
+        self._setup_event_logging()
+
+        # Start all tasks
+        for task_name, task in self.tasks.items():
+            self._logger.info(f"Starting task: {task_name}")
+            await task.start()
+
+        self._logger.info(f"All {len(self.tasks)} tasks started")
+        self._logger.info("Mainspring is running. Press Ctrl+C to stop.")
+        
+        # Send startup notification
+        await self._send_discord_notification(
+            f"**Mainspring Started**\n\n"
+            f"Tasks enabled: {', '.join(self.tasks.keys())}\n"
+        )
+
+    async def stop(self):
+        """Stop all tasks"""
+        self._logger.info("Stopping all tasks...")
+
+        # Stop all tasks
+        stop_tasks = [task.stop() for task in self.tasks.values()]
+        await asyncio.gather(*stop_tasks, return_exceptions=True)
+
+        self._logger.info("All tasks stopped")
+        
+        # Send shutdown notification
+        await self._send_discord_notification(
+            f"**Mainspring Stopped**\n\n"
+            f"Tasks were: {', '.join(self.tasks.keys())}\n"
+        )
+
+    async def run(self):
+        """Main run loop"""
+        try:
+            await self.start()
+
+            # Wait for shutdown signal
+            await self._shutdown_event.wait()
+
+        except Exception as e:
+            self._logger.error(f"Fatal error: {e}", exc_info=True)
+        finally:
+            await self.stop()
+
+
+async def main():
+    """Entry point"""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Mainspring - BitCraft data extraction orchestrator")
+    parser.add_argument(
+        "-c", "--config",
+        default="config.yml",
+        help="Path to configuration file (default: config.yml)"
+    )
+
+    args = parser.parse_args()
+
+    app = Mainspring(config_path=args.config)
+    await app.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/mainspring/mainspring/tasks/__init__.py
+++ b/utils/mainspring/mainspring/tasks/__init__.py
@@ -1,0 +1,17 @@
+"""
+Task implementations for mainspring.
+
+Concrete tasks that monitor various aspects of the BitCraft ecosystem.
+"""
+
+from .schema_monitor import SchemaMonitorTask
+from .table_subscriber import TableSubscriberTask
+from .asset_monitor import AssetMonitorTask
+from .workflow_monitor import WorkflowMonitorTask
+
+__all__ = [
+    "SchemaMonitorTask",
+    "TableSubscriberTask",
+    "AssetMonitorTask",
+    "WorkflowMonitorTask",
+]

--- a/utils/mainspring/mainspring/tasks/asset_monitor.py
+++ b/utils/mainspring/mainspring/tasks/asset_monitor.py
@@ -1,0 +1,152 @@
+"""
+Asset monitor task for detecting Steam depot manifest changes.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+from ..core import EventBus, ChangeDetector, PeriodicChangeMonitorTask
+
+
+class AssetChangeDetector(ChangeDetector):
+    """Detects changes in Steam depot manifest across multiple branches"""
+
+    def __init__(self, app_id: int, depot_id: int, branches: list[str],
+                 steam_username: Optional[str] = None,
+                 steam_password: Optional[str] = None):
+        self.app_id = app_id
+        self.depot_id = depot_id
+        self.branches = branches
+        self.steam_username = steam_username
+        self.steam_password = steam_password
+        self._last_manifest_ids: Dict[str, int] = {}
+        self._logger = logging.getLogger("mainspring.detectors.asset")
+
+    async def has_changed(self) -> tuple[bool, Dict[str, Any]]:
+        """Check if the Steam depot manifest has changed for any monitored branches"""
+        if not self.branches:
+            self._logger.debug("No branches configured for asset monitor, skipping check")
+            return False, {}
+
+        self._logger.debug("Checking for asset changes...")
+        try:
+            loop = asyncio.get_event_loop()
+            manifest_ids = await loop.run_in_executor(None, self._get_manifest_ids)
+
+            if not manifest_ids:
+                self._logger.warning("Failed to fetch manifest IDs from Steam")
+                return False, {}
+
+            if not self._last_manifest_ids:
+                self._logger.info(f"Initial manifest IDs: {manifest_ids}")
+                self._last_manifest_ids = manifest_ids.copy()
+                return False, {}
+
+            changes = {}
+            for branch, manifest_id in manifest_ids.items():
+                old_id = self._last_manifest_ids.get(branch)
+                
+                if old_id is None:
+                    self._logger.info(f"Now tracking branch '{branch}': {manifest_id}")
+                    self._last_manifest_ids[branch] = manifest_id
+                elif manifest_id != old_id:
+                    changes[branch] = {
+                        "old_manifest_id": old_id,
+                        "new_manifest_id": manifest_id
+                    }
+                    self._last_manifest_ids[branch] = manifest_id
+
+            if changes:
+                branch_list = ", ".join(changes.keys())
+                context = {
+                    "source": "asset_monitor",
+                    "description": f"Steam depot manifest changed for branches: {branch_list}",
+                    "branches_changed": list(changes.keys()),
+                    "changes": changes,
+                    "app_id": self.app_id,
+                    "depot_id": self.depot_id
+                }
+                return True, context
+
+            self._logger.debug(f"Manifests unchanged for all branches")
+            return False, {}
+        except Exception as e:
+            self._logger.error(f"Error checking Steam manifest: {e}", exc_info=True)
+            return False, {}
+
+    def _get_manifest_ids(self) -> Dict[str, int]:
+        """Get the current manifest IDs for all monitored branches from Steam."""
+        steam_client = None
+        try:
+            from steam.client import SteamClient
+            from steam.enums import EResult
+
+            steam_client = SteamClient()
+
+            if self.steam_username and self.steam_password:
+                self._logger.debug("Logging into Steam with credentials...")
+                result = steam_client.login(self.steam_username, self.steam_password)
+            else:
+                self._logger.debug("Logging into Steam anonymously...")
+                result = steam_client.anonymous_login()
+
+            if result != EResult.OK:
+                self._logger.error(f"Steam login failed: {result}")
+                return {}
+
+            app_info = steam_client.get_product_info(apps=[self.app_id])
+
+            if not app_info or 'apps' not in app_info or self.app_id not in app_info['apps']:
+                self._logger.error(f"Failed to get app info for {self.app_id}")
+                return {}
+
+            app_data = app_info['apps'][self.app_id]
+            depots = app_data.get('depots', {})
+            depot_info = depots.get(str(self.depot_id), {})
+            manifests = depot_info.get('manifests', {})
+
+            manifest_ids = {}
+            for branch in self.branches:
+                manifest_data = manifests.get(branch, {})
+                manifest_gid = manifest_data.get('gid')
+
+                if manifest_gid:
+                    manifest_ids[branch] = int(manifest_gid)
+                else:
+                    self._logger.warning(f"No manifest found for depot {self.depot_id}, branch {branch}")
+
+            if manifest_ids:
+                self._logger.debug(f"Retrieved {len(manifest_ids)} manifest IDs from Steam")
+            
+            return manifest_ids
+
+        except Exception as e:
+            self._logger.error(f"Error in _get_manifest_ids: {e}", exc_info=True)
+            return {}
+        finally:
+            if steam_client:
+                try:
+                    steam_client.logout()
+                except:
+                    pass
+
+
+class AssetMonitorTask(PeriodicChangeMonitorTask):
+    """Monitors Steam depot manifest for asset updates across multiple branches."""
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus):
+        super().__init__(name, config, event_bus)
+
+        branches = config.get("branches")
+        if branches is None:
+            branch = config.get("branch", "preview")
+            branches = [branch]
+
+        self.detector = AssetChangeDetector(
+            app_id=config.get("app_id", 3454650),
+            depot_id=config.get("depot_id", 3454651),
+            branches=branches,
+            steam_username=config.get("steam_username"),
+            steam_password=config.get("steam_password")
+        )

--- a/utils/mainspring/mainspring/tasks/schema_monitor.py
+++ b/utils/mainspring/mainspring/tasks/schema_monitor.py
@@ -1,0 +1,126 @@
+"""
+Schema monitor task for detecting SpacetimeDB schema changes.
+"""
+
+import hashlib
+import json
+from typing import Any, Dict, Optional
+
+from ..core import EventBus, ChangeDetector, PeriodicChangeMonitorTask
+from .utils import fetch_schema, get_static_tables_from_schema
+
+
+class SchemaChangeDetector(ChangeDetector):
+    """Detects changes in SpacetimeDB schema and static table lists"""
+
+    def __init__(self, host: str, global_module: str, region_module: str):
+        self.host = host
+        self.global_module = global_module
+        self.region_module = region_module
+        self._last_global_hash: Optional[str] = None
+        self._last_region_hash: Optional[str] = None
+        self._static_tables_cache: list[str] = []
+
+    @staticmethod
+    def _hash_schema(schema: Dict[str, Any]) -> str:
+        """Create a hash of the schema for comparison"""
+        # Sort the row_level_security section to avoid false positives from ordering differences
+        # (server sometimes returns identical schema with rls section in different order)
+        if "row_level_security" in schema:
+            rls = schema["row_level_security"]
+            if isinstance(rls, list):
+                schema["row_level_security"] = sorted(rls, key=lambda x: x.get('sql', ''))
+
+        # Serialize and hash the schema
+        schema_str = json.dumps(schema, sort_keys=True)
+        return hashlib.sha256(schema_str.encode()).hexdigest()
+
+    async def has_changed(self) -> tuple[bool, Dict[str, Any]]:
+        """Check if schema has changed and if static table list has changed"""
+        global_schema = await fetch_schema(self.host, self.global_module)
+        region_schema = await fetch_schema(self.host, self.region_module)
+
+        if not global_schema or not region_schema:
+            return False, {}
+
+        global_hash = self._hash_schema(global_schema)
+        region_hash = self._hash_schema(region_schema)
+
+        changed = False
+        changes = {}
+
+        if self._last_global_hash is None:
+            # First run, just store the hash and static tables
+            self._last_global_hash = global_hash
+            self._last_region_hash = region_hash
+            # Use region module for static table detection (has all desc tables)
+            self._static_tables_cache = get_static_tables_from_schema(region_schema)
+            return False, {}
+
+        if global_hash != self._last_global_hash:
+            changed = True
+            changes["global"] = {
+                "old_hash": self._last_global_hash,
+                "new_hash": global_hash,
+                "tables": len(global_schema.get("tables", []))
+            }
+            self._last_global_hash = global_hash
+
+        if region_hash != self._last_region_hash:
+            changed = True
+            changes["region"] = {
+                "old_hash": self._last_region_hash,
+                "new_hash": region_hash,
+                "tables": len(region_schema.get("tables", []))
+            }
+            self._last_region_hash = region_hash
+
+            # Check if static tables changed when region schema changes
+            new_static_tables = get_static_tables_from_schema(region_schema)
+            if self._static_tables_cache:
+                old_set = set(self._static_tables_cache)
+                new_set = set(new_static_tables)
+
+                if old_set != new_set:
+                    added_tables = sorted(list(new_set - old_set))
+                    removed_tables = sorted(list(old_set - new_set))
+
+                    changes["static_tables"] = {
+                        "tables_added": added_tables,
+                        "tables_removed": removed_tables,
+                        "total_tables": len(new_static_tables)
+                    }
+
+            self._static_tables_cache = new_static_tables
+
+        # Build description
+        description_parts = []
+        if "global" in changes:
+            description_parts.append("global schema")
+        if "region" in changes:
+            description_parts.append("region schema")
+        if "static_tables" in changes:
+            st = changes["static_tables"]
+            description_parts.append(f"{len(st['tables_added'])} tables added, {len(st['tables_removed'])} removed")
+
+        return changed, {
+            "source": "schema_monitor",
+            "description": f"Schema changed: {', '.join(description_parts)}",
+            "changes": changes
+        }
+
+
+class SchemaMonitorTask(PeriodicChangeMonitorTask):
+    """
+    Monitors SpacetimeDB schema for changes.
+    Checks periodically and triggers actions when schema changes are detected.
+    """
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus,
+                 stdb_config: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.detector = SchemaChangeDetector(
+            host=stdb_config.get("host"),
+            global_module=stdb_config.get("global_module"),
+            region_module=stdb_config.get("region_module")
+        )

--- a/utils/mainspring/mainspring/tasks/table_subscriber.py
+++ b/utils/mainspring/mainspring/tasks/table_subscriber.py
@@ -1,0 +1,258 @@
+"""
+Table subscriber task for monitoring SpacetimeDB table changes.
+"""
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from websockets.asyncio.client import connect
+from websockets import Subprotocol
+from websockets.exceptions import WebSocketException
+
+from ..core import Task, EventBus
+from .utils import fetch_schema, get_static_tables_from_schema
+
+
+class TableSubscriberTask(Task):
+    """
+    Subscribes to SpacetimeDB tables and monitors for changes.
+    Uses websocket connection to receive real-time updates.
+    Filters to static tables (desc tables and extras) if no tables are specified.
+    """
+
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus,
+                 stdb_config: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.host = stdb_config.get("host")
+        self.bearer_token = config.get("bearer_token", stdb_config.get("bearer_token"))
+        self.module = config.get("module")
+        if self.module == "__region__" or not self.module:
+            self.module = stdb_config.get("region_module")
+        elif self.module == "__global__":
+            self.module = stdb_config.get("global_module")
+        self.reconnect_on_error = config.get("reconnect_on_error", True)
+        self.tables_to_monitor = config.get("tables", [])  # Specific tables or empty for static tables
+        self.queries_to_monitor = config.get("queries", [])  # Custom SQL queries to monitor
+        self.trigger_interval = config.get("trigger_interval", 60)  # Seconds between triggers
+
+    async def run(self):
+        """Main subscription loop"""
+        while self._running:
+            try:
+                await self._subscribe_and_monitor()
+            except Exception as e:
+                if isinstance(e, WebSocketException):
+                    self._logger.error(f"WebSocket error: {e}")
+                else:
+                    self._logger.error(f"Unexpected error: {e}", exc_info=True)
+                if not self.reconnect_on_error or not self._running:
+                    break
+                self._logger.info("Reconnecting in 30 seconds...")
+                await asyncio.sleep(30)
+
+    async def _fetch_static_tables(self) -> list[str]:
+        """Fetch schema and filter to static tables (desc tables + extras)"""
+        # Use shared function to fetch schema
+        schema = await fetch_schema(self.host, self.module)
+
+        if not schema:
+            self._logger.error("Failed to fetch schema")
+            return []
+
+        # Use shared utility function for filtering
+        static_tables = get_static_tables_from_schema(schema)
+
+        self._logger.info(f"Found {len(static_tables)} static tables to monitor")
+        return static_tables
+
+    async def _subscribe_and_monitor(self):
+        """Connect to SpacetimeDB and monitor for changes"""
+        # Build a list of queries to subscribe to before connecting to WebSocket
+
+        # Option 1: Custom SQL queries
+        if self.queries_to_monitor:
+            queries = self.queries_to_monitor
+            self._logger.info(f"Using {len(queries)} custom SQL queries")
+
+        # Option 2: Specific table names
+        elif self.tables_to_monitor:
+            queries = [f"SELECT * FROM {table};" for table in self.tables_to_monitor]
+            self._logger.info(f"Using {len(self.tables_to_monitor)} configured tables")
+
+        # Option 3: Auto-detect static tables
+        else:
+            # Fetch static tables from schema
+            tables = await self._fetch_static_tables()
+
+            if not tables:
+                self._logger.error("No tables to subscribe to, waiting...")
+                await asyncio.sleep(300)
+                return
+
+            # Convert table names to queries
+            queries = [f"SELECT * FROM {table};" for table in tables]
+
+        # Now connect to WebSocket with queries ready
+        uri = f"wss://{self.host}/v1/database/{self.module}/subscribe"
+        proto = Subprotocol('v1.json.spacetimedb')
+        headers = {}
+
+        if self.bearer_token:
+            headers["Authorization"] = f"Bearer {self.bearer_token}"
+
+        self._logger.info(f"Connecting to {uri}")
+
+        async with connect(
+                uri,
+                additional_headers=headers,
+                subprotocols=[proto],
+                max_size=None,
+                max_queue=None
+        ) as ws:
+            # The first message is IdentityToken
+            _ = await ws.recv()
+            self._logger.debug(f"Received identity token")
+
+            # Subscribe to all queries using SubscribeMulti pattern
+            for idx, query in enumerate(queries):
+                subscribe_msg = json.dumps({
+                    "SubscribeMulti": {
+                        "request_id": idx,
+                        "query_id": {"id": idx},
+                        "query_strings": [query]
+                    }
+                })
+                await ws.send(subscribe_msg)
+
+            self._logger.info(f"Subscribed to {len(queries)} queries")
+
+            update_count = 0
+            accumulated_changes = {}
+            trigger_task: Optional[asyncio.Task] = None
+
+            async def trigger_actions_delayed():
+                """Delayed action trigger - waits for a quiet period before triggering"""
+                await asyncio.sleep(self.trigger_interval)
+                
+                if accumulated_changes:
+                    # Calculate summary
+                    total_tables = len(accumulated_changes)
+                    total_inserts = sum(c["inserts"] for c in accumulated_changes.values())
+                    total_deletes = sum(c["deletes"] for c in accumulated_changes.values())
+                    total_updates = sum(c["updates"] for c in accumulated_changes.values())
+
+                    summary = {
+                        "tables_updated": total_tables,
+                        "total_inserts": total_inserts,
+                        "total_deletes": total_deletes,
+                        "total_updates": total_updates
+                    }
+
+                    self._logger.info(f"Triggering actions for {total_tables} tables: {summary}")
+                    await self.trigger_actions({
+                        "source": "table_subscriber",
+                        "timestamp": datetime.now().isoformat(),
+                        "changes": accumulated_changes,
+                        "summary": summary,
+                        "description": f"Detected {total_tables} tables updated in SpacetimeDB."
+                    })
+
+                    accumulated_changes.clear()
+
+            # Monitor for updates
+            while self._running:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                    data = json.loads(msg)
+
+                    if "InitialSubscription" in data:
+                        continue
+
+                    # Handle TransactionUpdate messages
+                    if "TransactionUpdate" in data:
+                        tx_update = data["TransactionUpdate"]
+
+                        # Check for failures
+                        if "Failed" in tx_update.get("status", {}):
+                            failure = tx_update["status"]["Failed"]
+                            self._logger.error(f"Transaction failed: {failure}")
+                            continue
+
+                        # Process committed updates
+                        if "Committed" in tx_update.get("status", {}):
+                            update_count += 1
+                            tables_updated = tx_update["status"]["Committed"].get("tables", [])
+
+                            # Process each table update
+                            for table_update in tables_updated:
+                                table_name = table_update.get("table_name")
+                                updates = table_update.get("updates", [])
+
+                                # Track changes per table
+                                if table_name not in accumulated_changes:
+                                    accumulated_changes[table_name] = {
+                                        "inserts": 0,
+                                        "deletes": 0,
+                                        "updates": 0
+                                    }
+
+                                for update in updates:
+                                    inserts = update.get("inserts", [])
+                                    deletes = update.get("deletes", [])
+
+                                    # Try to match inserted and deleted rows by ID to detect updates
+                                    matched_updates = 0
+                                    if inserts and deletes:
+                                        try:
+                                            # Parse insert and delete rows as JSON objects
+                                            inserted_rows = [json.loads(row) for row in inserts]
+                                            deleted_rows = [json.loads(row) for row in deletes]
+
+                                            # Check if rows are dicts with "id" key
+                                            if (inserted_rows and deleted_rows and
+                                                    isinstance(inserted_rows[0], dict) and "id" in inserted_rows[0] and
+                                                    isinstance(deleted_rows[0], dict) and "id" in deleted_rows[0]):
+                                                # Extract IDs from row objects
+                                                inserted_ids = {row["id"] for row in inserted_rows if isinstance(row, dict) and "id" in row}
+                                                deleted_ids = {row["id"] for row in deleted_rows if isinstance(row, dict) and "id" in row}
+
+                                                # Count matching IDs as updates
+                                                matched_updates = len(inserted_ids & deleted_ids)
+                                        except (json.JSONDecodeError, KeyError, TypeError) as e:
+                                            # If we can't parse or match IDs, just count inserts/deletes separately
+                                            self._logger.debug(f"Could not match IDs for {table_name}: {e}")
+
+                                    # Count total inserts and deletes
+                                    accumulated_changes[table_name]["inserts"] += len(inserts)
+                                    accumulated_changes[table_name]["deletes"] += len(deletes)
+                                    accumulated_changes[table_name]["updates"] += matched_updates
+
+                            self._logger.debug(f"Transaction #{update_count}: {len(tables_updated)} tables updated")
+
+                            # Debounce pattern: Cancel previous trigger and schedule new one
+                            # This ensures we trigger after trigger_interval seconds of NO updates
+                            if trigger_task and not trigger_task.done():
+                                trigger_task.cancel()
+                                try:
+                                    await trigger_task
+                                except asyncio.CancelledError:
+                                    pass
+
+                            # Schedule new trigger after quiet period
+                            trigger_task = asyncio.create_task(trigger_actions_delayed())
+                except asyncio.TimeoutError:
+                    # No message received, just continue
+                    continue
+                except json.JSONDecodeError as e:
+                    self._logger.warning(f"Failed to decode message: {e}")
+                    continue
+            
+            # Clean up: if we're shutting down and there's a pending trigger, cancel it
+            if trigger_task and not trigger_task.done():
+                trigger_task.cancel()
+                try:
+                    await trigger_task
+                except asyncio.CancelledError:
+                    pass

--- a/utils/mainspring/mainspring/tasks/utils.py
+++ b/utils/mainspring/mainspring/tasks/utils.py
@@ -1,0 +1,60 @@
+"""
+Utility functions shared across tasks.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+import aiohttp
+import re
+
+
+async def fetch_schema(host: str, module: str) -> Optional[Dict[str, Any]]:
+    """
+    Fetch schema from SpacetimeDB.
+    Shared utility function used by SchemaChangeDetector and TableSubscriberTask.
+    """
+    url = f"https://{host}/v1/database/{module}/schema"
+    params = {"version": "9"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params) as response:
+                if response.status == 200:
+                    return await response.json()
+                return None
+    except Exception as e:
+        logging.getLogger("mainspring.utils").error(f"Error fetching schema: {e}")
+        return None
+
+
+def get_static_tables_from_schema(schema: Dict[str, Any]) -> list[str]:
+    """
+    Extract static tables from a schema (desc tables and extras).
+    Shared utility function used by SchemaChangeDetector and TableSubscriberTask.
+    """
+    desc_re = re.compile(r".+_desc(_v\d+)?$")
+    extra_tables = ['claim_tile_cost']
+
+    tables = schema.get("tables", [])
+    static_tables = []
+
+    for tbl in tables:
+        if 'Public' not in tbl.get('table_access', []):
+            continue
+
+        name = tbl['name']
+
+        # Include desc tables
+        if desc_re.match(name):
+            static_tables.append(name)
+            continue
+
+        # Exclude state tables
+        if name.endswith('_state'):
+            continue
+
+        # Include extra tables
+        if name in extra_tables:
+            static_tables.append(name)
+
+    return static_tables

--- a/utils/mainspring/mainspring/tasks/workflow_monitor.py
+++ b/utils/mainspring/mainspring/tasks/workflow_monitor.py
@@ -1,0 +1,181 @@
+"""
+Workflow monitor task for tracking GitHub Actions workflow runs.
+"""
+
+import asyncio
+from typing import Any, Dict, Optional
+import aiohttp
+
+from ..core import Task, EventBus, Event, EventType
+
+
+class WorkflowMonitorTask(Task):
+    """
+    Monitors GitHub workflow runs triggered by actions and executes follow-up actions on completion.
+    Subscribes to ACTION_COMPLETED events, polls workflow status, and triggers configured actions.
+    """
+    
+    def __init__(self, name: str, config: Dict[str, Any], event_bus: EventBus, 
+                 github_config: Dict[str, Any], discord_config: Dict[str, Any]):
+        super().__init__(name, config, event_bus)
+        self.github_config = github_config
+        self.discord_config = discord_config
+        self.poll_interval = config.get("poll_interval", 30)  # Check every 30 seconds
+        self.on_complete = config.get("on_complete", {})  # Map of action_name -> follow-up actions
+        self._monitored_runs: Dict[str, Dict[str, Any]] = {}  # run_url -> metadata
+        self._pending_actions: asyncio.Queue = asyncio.Queue()
+    
+    async def run(self):
+        """Main monitoring loop"""
+        self._logger.info(f"Workflow monitor started, polling every {self.poll_interval}s")
+        
+        # Subscribe to ACTION_COMPLETED events
+        # noinspection PyTypeChecker
+        self.event_bus.subscribe(EventType.ACTION_COMPLETED, self._handle_action_completed)
+        
+        # Start polling loop
+        while self._running:
+            try:
+                # Process any new runs to monitor
+                while not self._pending_actions.empty():
+                    action_info = await self._pending_actions.get()
+                    run_url = action_info.get("run_url")
+                    if run_url:
+                        self._monitored_runs[run_url] = action_info
+                        self._logger.info(f"Now monitoring workflow: {run_url}")
+                
+                # Poll all monitored runs
+                if self._monitored_runs:
+                    await self._poll_runs()
+                
+                # Wait before next poll
+                await asyncio.sleep(self.poll_interval)
+                
+            except Exception as e:
+                self._logger.error(f"Error in workflow monitor: {e}", exc_info=True)
+                await asyncio.sleep(60)
+    
+    async def _handle_action_completed(self, event: Event):
+        """Handle ACTION_COMPLETED events from GitHub dispatch actions"""
+        action_name = event.source
+        action_data = event.data.get("action_data", {})
+        
+        # Only monitor GitHub dispatch actions that have run_url
+        if "run_url" not in action_data:
+            return
+        
+        # Check if we have follow-up actions configured for this action
+        if action_name not in self.on_complete:
+            self._logger.debug(f"No follow-up actions configured for {action_name}")
+            return
+        
+        # Queue this run for monitoring
+        run_info = {
+            "action_name": action_name,
+            "run_url": action_data["run_url"],
+            "workflow": action_data.get("workflow"),
+            "follow_up_actions": self.on_complete[action_name]
+        }
+        
+        await self._pending_actions.put(run_info)
+        self._logger.info(f"Queued workflow for monitoring: {action_name}")
+    
+    async def _poll_runs(self):
+        """Poll all monitored workflow runs and trigger follow-ups on completion"""
+        completed_runs = []
+        
+        for run_url, run_info in self._monitored_runs.items():
+            try:
+                # run_url is already the full API URL for the run
+                headers = {
+                    "Authorization": f"Bearer {self.github_config.get('token')}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2026-03-10"
+                }
+                
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(run_url, headers=headers) as response:
+                        if response.status != 200:
+                            self._logger.warning(f"Failed to fetch run status: {response.status}")
+                            continue
+                        
+                        run_data = await response.json()
+                        status = run_data.get("status")
+                        conclusion = run_data.get("conclusion")
+                        run_id = run_data.get("id")
+                        
+                        self._logger.debug(f"Run {run_id}: status={status}, conclusion={conclusion}")
+                        
+                        # Check if workflow completed
+                        if status == "completed":
+                            if conclusion == "success":
+                                self._logger.info(f"Workflow {run_info['action_name']} completed successfully!")
+                                
+                                # Trigger follow-up actions
+                                follow_up_actions = run_info["follow_up_actions"]
+                                context = {
+                                    "source": f"workflow_monitor",
+                                    "trigger_action": run_info["action_name"],
+                                    "workflow": run_info["workflow"],
+                                    "run_url": run_url,
+                                    "run_id": run_id,
+                                    "conclusion": conclusion
+                                }
+                                
+                                for action_config in follow_up_actions:
+                                    await self._execute_follow_up_action(action_config, context)
+                            else:
+                                self._logger.warning(f"Workflow {run_info['action_name']} completed with conclusion: {conclusion}")
+                            
+                            # Mark for removal
+                            completed_runs.append(run_url)
+                        elif status in ("cancelled", "failure", "timed_out", "action_required", "stale"):
+                            self._logger.warning(f"Workflow {run_info['action_name']} ended with status: {status}")
+                            completed_runs.append(run_url)
+                        # Otherwise still in progress (queued, in_progress, waiting)
+                        
+            except Exception as e:
+                self._logger.error(f"Error polling run {run_url}: {e}", exc_info=True)
+        
+        # Remove completed runs from monitoring
+        for run_url in completed_runs:
+            del self._monitored_runs[run_url]
+            self._logger.debug(f"Stopped monitoring: {run_url}")
+    
+    async def _execute_follow_up_action(self, action_config: Dict[str, Any], context: Dict[str, Any]):
+        """Execute a follow-up action when workflow completes"""
+        action_type = action_config.get("type")
+        
+        self._logger.info(f"Executing follow-up action: {action_type}")
+        
+        # Import here to avoid circular dependency
+        from ..actions import GitHubDispatchAction, DiscordWebhookAction
+        
+        try:
+            if action_type == "github_dispatch":
+                action = GitHubDispatchAction(
+                    name=f"followup_{action_type}",
+                    config=action_config,
+                    event_bus=self.event_bus,
+                    github_config=self.github_config
+                )
+            elif action_type == "discord":
+                action = DiscordWebhookAction(
+                    name=f"followup_{action_type}",
+                    config=action_config,
+                    event_bus=self.event_bus,
+                    discord_config=self.discord_config
+                )
+            else:
+                self._logger.warning(f"Unsupported follow-up action type: {action_type}")
+                return
+            
+            # Execute the follow-up action
+            success, _ = await action.execute(context)
+            if success:
+                self._logger.info(f"Follow-up action {action_type} completed successfully")
+            else:
+                self._logger.warning(f"Follow-up action {action_type} failed")
+                
+        except Exception as e:
+            self._logger.error(f"Error executing follow-up action: {e}", exc_info=True)

--- a/utils/mainspring/requirements.txt
+++ b/utils/mainspring/requirements.txt
@@ -1,0 +1,6 @@
+websockets~=15.0.1
+python-dotenv~=1.1.1
+requests~=2.32.5
+aiohttp~=3.11.0
+pyyaml~=6.0.1
+steam[client]~=1.4.4

--- a/utils/mainspring/run.py
+++ b/utils/mainspring/run.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Simple runner script for mainspring.
+Usage: python run.py [--config config.yml]
+"""
+
+import sys
+import os
+import asyncio
+
+# Add current directory to path so we can import the mainspring package
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mainspring import main
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Workflows are now dispatched by the mainspring utility, which is configured to monitor schema on global and region modules, static tables on a region module, and preview branch Steam depot. Existing cron schedules switched to once a day as a backup.